### PR TITLE
hdong: split some phone number from client and admin.

### DIFF
--- a/src/Infrastructure/BotSharp.Abstraction/Repositories/IBotSharpRepository.cs
+++ b/src/Infrastructure/BotSharp.Abstraction/Repositories/IBotSharpRepository.cs
@@ -26,7 +26,7 @@ public interface IBotSharpRepository : IHaveServiceProvider
 
     #region User
     User? GetUserByEmail(string email) => throw new NotImplementedException();
-    User? GetUserByPhone(string phone, string role = null, string regionCode = "CN") => throw new NotImplementedException();
+    User? GetUserByPhone(string phone, string type = "client", string regionCode = "CN") => throw new NotImplementedException();
     User? GetAffiliateUserByPhone(string phone) => throw new NotImplementedException();
     User? GetUserById(string id) => throw new NotImplementedException();
     List<User> GetUserByIds(List<string> ids) => throw new NotImplementedException();

--- a/src/Infrastructure/BotSharp.Core/Repository/FileRepository/FileRepository.User.cs
+++ b/src/Infrastructure/BotSharp.Core/Repository/FileRepository/FileRepository.User.cs
@@ -11,13 +11,13 @@ public partial class FileRepository
         return Users.FirstOrDefault(x => x.Email == email.ToLower());
     }
 
-    public User? GetUserByPhone(string phone, string? role = null, string regionCode = "CN")
+    public User? GetUserByPhone(string phone, string? type = "client", string regionCode = "CN")
     {
         var query = Users.Where(x => x.Phone == phone);
 
-        if (!string.IsNullOrEmpty(role))
+        if (!string.IsNullOrEmpty(type))
         {
-            query = query.Where(x => x.Role == role);
+            query = query.Where(x => x.Type == type);
         }
 
         if (!string.IsNullOrEmpty(regionCode))

--- a/src/Infrastructure/BotSharp.Core/Users/Services/UserService.cs
+++ b/src/Infrastructure/BotSharp.Core/Users/Services/UserService.cs
@@ -172,7 +172,7 @@ public class UserService : IUserService
         var base64 = Encoding.UTF8.GetString(Convert.FromBase64String(authorization));
         var (id, password) = base64.SplitAsTuple(":");
         var db = _services.GetRequiredService<IBotSharpRepository>();
-        var record = db.GetUserByPhone(id,"admin");
+        var record = db.GetUserByPhone(id, role: "admin");
         var isCanLogin = record != null && !record.IsDisabled
             && record.Type == UserType.Internal && new List<string>
             {

--- a/src/Infrastructure/BotSharp.Core/Users/Services/UserService.cs
+++ b/src/Infrastructure/BotSharp.Core/Users/Services/UserService.cs
@@ -172,7 +172,7 @@ public class UserService : IUserService
         var base64 = Encoding.UTF8.GetString(Convert.FromBase64String(authorization));
         var (id, password) = base64.SplitAsTuple(":");
         var db = _services.GetRequiredService<IBotSharpRepository>();
-        var record = db.GetUserByPhone(id, role: "admin");
+        var record = db.GetUserByPhone(id, type: "internal");
         var isCanLogin = record != null && !record.IsDisabled
             && record.Type == UserType.Internal && new List<string>
             {

--- a/src/Plugins/BotSharp.Plugin.MongoStorage/Repository/MongoRepository.User.cs
+++ b/src/Plugins/BotSharp.Plugin.MongoStorage/Repository/MongoRepository.User.cs
@@ -13,7 +13,7 @@ public partial class MongoRepository
         return user != null ? user.ToUser() : null;
     }
 
-    public User? GetUserByPhone(string phone, string role = null, string regionCode = "CN")
+    public User? GetUserByPhone(string phone, string role = "client", string regionCode = "CN")
     {
         string phoneSecond = string.Empty;
         // if phone number length is less than 4, return null
@@ -25,8 +25,8 @@ public partial class MongoRepository
         phoneSecond = phone.StartsWith("+86") ? phone.Replace("+86", "") : $"+86{phone}";
 
         var user = _dc.Users.AsQueryable().FirstOrDefault(x => (x.Phone == phone || x.Phone == phoneSecond) && x.Type != UserType.Affiliate
-        && (x.RegionCode == regionCode || string.IsNullOrWhiteSpace(x.RegionCode)) 
-        && (role == "admin" ? x.Role == "admin" || x.Role == "root" : true));
+        && (x.RegionCode == regionCode || string.IsNullOrWhiteSpace(x.RegionCode))
+        && (role == "client" ? x.Role == "client" || x.Role == "user" : role == "admin" ? x.Role == "admin" || x.Role == "root" : true));
         return user != null ? user.ToUser() : null;
     }
 
@@ -245,7 +245,7 @@ public partial class MongoRepository
             user.AgentActions = agentActions;
             return user;
         }
-        
+
         var agentIds = userAgents.Select(x => x.AgentId)?.Distinct().ToList();
         if (!agentIds.IsNullOrEmpty())
         {

--- a/src/Plugins/BotSharp.Plugin.MongoStorage/Repository/MongoRepository.User.cs
+++ b/src/Plugins/BotSharp.Plugin.MongoStorage/Repository/MongoRepository.User.cs
@@ -13,7 +13,7 @@ public partial class MongoRepository
         return user != null ? user.ToUser() : null;
     }
 
-    public User? GetUserByPhone(string phone, string role = "client", string regionCode = "CN")
+    public User? GetUserByPhone(string phone, string type = "client", string regionCode = "CN")
     {
         string phoneSecond = string.Empty;
         // if phone number length is less than 4, return null
@@ -24,9 +24,9 @@ public partial class MongoRepository
 
         phoneSecond = phone.StartsWith("+86") ? phone.Replace("+86", "") : $"+86{phone}";
 
-        var user = _dc.Users.AsQueryable().FirstOrDefault(x => (x.Phone == phone || x.Phone == phoneSecond) && x.Type != UserType.Affiliate
+        var user = _dc.Users.AsQueryable().FirstOrDefault(x => (x.Phone == phone || x.Phone == phoneSecond) 
         && (x.RegionCode == regionCode || string.IsNullOrWhiteSpace(x.RegionCode))
-        && (role == "client" ? x.Role == "client" || x.Role == "user" : role == "admin" ? x.Role == "admin" || x.Role == "root" : true));
+        && (x.Type == type));
         return user != null ? user.ToUser() : null;
     }
 


### PR DESCRIPTION
Hi  @Oceania2018  , 帮忙合并一下，这个改动是为了将Qtoss这边手机注册的用户和分销超管端手机注册的用户分开。

目前的逻辑：
Qtoss 的注册用户是 Role 等于”client"(没有Type),或者“user”(Type="client"),两种情况。
分销超管端注册用户是 Role 等于“admin” 或者 “root”两种情况。

现在接口通过手机号码查询账号的API，默认使用 role="client", 会用Qtoss原有的逻辑 . 
超管端的检查都加了 role:"admin"。 
我本地测试了，两边都不影响了。

任何其它的问题，或者没有考虑到的逻辑，帮忙纠正一下，谢谢！